### PR TITLE
Added computed columns to Annotation, and Entry list views

### DIFF
--- a/src/annotation/admin.py
+++ b/src/annotation/admin.py
@@ -23,6 +23,45 @@ class PageAdmin(admin.ModelAdmin):
     list_filter = ["volume"]
 
 
+class EntryAdmin(admin.ModelAdmin):
+    """Overrides the default admin options for Entry."""
+
+    list_display = ["entry_title_word", "entry_text_length"]
+
+    def entry_title_word(self, entry):
+        """Get the localized title word of the provided entry.
+
+        Parameters
+        ----------
+        entry: models.Entry, required
+            The entry object.
+
+        Returns
+        -------
+        title_word: str
+            The title word of the entry.
+        """
+        return entry.title_word
+
+    def entry_text_length(self, entry):
+        """Get the text length of the provided entry.
+
+        Parameters
+        ----------
+        entry: models.Entry, required
+            The entry object.
+
+        Returns
+        -------
+        title_word: str
+            The title word of the entry.
+        """
+        return entry.text_length
+
+    entry_title_word.short_description = _("title word")
+    entry_text_length.short_description = _("text length")
+
+
 class EntryPageAdmin(admin.ModelAdmin):
     """Overrides the default admin options for EntryPage."""
 
@@ -41,7 +80,7 @@ class AnnotationAdmin(admin.ModelAdmin):
 admin.site.register(Volume, VolumeAdmin)
 admin.site.register(Page, PageAdmin)
 admin.site.register(Annotation, AnnotationAdmin)
-admin.site.register(Entry)
+admin.site.register(Entry, EntryAdmin)
 admin.site.register(EntryPage, EntryPageAdmin)
 
 admin.site.site_url = reverse_lazy('annotation:index')

--- a/src/annotation/admin.py
+++ b/src/annotation/admin.py
@@ -53,8 +53,8 @@ class EntryAdmin(admin.ModelAdmin):
 
         Returns
         -------
-        title_word: str
-            The title word of the entry.
+        length: int
+            The length of the text of the entry.
         """
         return entry.text_length
 
@@ -72,9 +72,26 @@ class EntryPageAdmin(admin.ModelAdmin):
 class AnnotationAdmin(admin.ModelAdmin):
     """Overrides the default admin options for Annotation."""
 
-    list_display = ["entry", "user", "status"]
+    list_display = ["entry", "annotation_text_length", "user", "status"]
     list_filter = ["status", "user"]
     ordering = ["entry"]
+
+    def annotation_text_length(self, annotation):
+        """Get the text length of the provided annotation.
+
+        Parameters
+        ----------
+        annotation: models.Annotation, required
+            The annotation object.
+
+        Returns
+        -------
+        length: int
+            The length of the annotation text.
+        """
+        return annotation.text_length
+
+    annotation_text_length.short_description = _("text length")
 
 
 admin.site.register(Volume, VolumeAdmin)

--- a/src/annotation/locale/ro/LC_MESSAGES/django.po
+++ b/src/annotation/locale/ro/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-28 22:15+0200\n"
+"POT-Creation-Date: 2024-12-08 20:39+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,9 +19,22 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?"
 "2:1));\n"
 
-#: src/annotation/admin.py:48 src/annotation/admin.py:49
+#: src/annotation/admin.py:61
+msgid "title word"
+msgstr "cuvânt-titlu"
+
+#: src/annotation/admin.py:62
+msgid "text length"
+msgstr "lungime text"
+
+#: src/annotation/admin.py:87 src/annotation/admin.py:88
+#: src/annotation/admin.py:89
 msgid "Admin eDTLR data"
 msgstr "Administrare date eDTLR"
+
+#: src/annotation/apps.py:8 src/annotation/models.py:142
+msgid "annotation"
+msgstr "adnotare"
 
 #: src/annotation/models.py:36 src/annotation/models.py:57
 msgid "volume"
@@ -43,7 +56,7 @@ msgstr "număr pagină"
 msgid "image path"
 msgstr "cale imagine"
 
-#: src/annotation/models.py:72 src/annotation/models.py:106
+#: src/annotation/models.py:72 src/annotation/models.py:116
 msgid "page"
 msgstr "pagină"
 
@@ -51,56 +64,52 @@ msgstr "pagină"
 msgid "pages"
 msgstr "pagini"
 
-#: src/annotation/models.py:89 src/annotation/models.py:103
-#: src/annotation/models.py:140
+#: src/annotation/models.py:99 src/annotation/models.py:113
+#: src/annotation/models.py:150
 msgid "entry"
 msgstr "intrare"
 
-#: src/annotation/models.py:90
+#: src/annotation/models.py:100
 msgid "entries"
 msgstr "intrări"
 
-#: src/annotation/models.py:111
+#: src/annotation/models.py:121
 msgid "page entry"
 msgstr "pagină intrare"
 
-#: src/annotation/models.py:112
+#: src/annotation/models.py:122
 msgid "page entries"
 msgstr "pagini intrări"
 
-#: src/annotation/models.py:125
+#: src/annotation/models.py:135
 msgid "In progress"
 msgstr "În desfășurare"
 
-#: src/annotation/models.py:126
+#: src/annotation/models.py:136
 msgid "Complete"
 msgstr "Completă"
 
-#: src/annotation/models.py:127
+#: src/annotation/models.py:137
 msgid "Conflict"
 msgstr "Conflict"
 
-#: src/annotation/models.py:132
-msgid "annotation"
-msgstr "adnotare"
-
-#: src/annotation/models.py:133
+#: src/annotation/models.py:143
 msgid "annotations"
 msgstr "adnotări"
 
-#: src/annotation/models.py:144
+#: src/annotation/models.py:154
 msgid "user"
 msgstr "utilizator"
 
-#: src/annotation/models.py:150
+#: src/annotation/models.py:160
 msgid "version"
 msgstr "versiune"
 
-#: src/annotation/models.py:155
+#: src/annotation/models.py:165
 msgid "row creation timestamp"
 msgstr "creat la"
 
-#: src/annotation/models.py:157
+#: src/annotation/models.py:167
 msgid "row update timestamp"
 msgstr "actualizat la"
 
@@ -130,11 +139,11 @@ msgstr "Adnotator eDTLR"
 msgid "Annotate text"
 msgstr "Adnotare text"
 
-#: src/annotation/templates/annotation/index.html:54
+#: src/annotation/templates/annotation/index.html:32
 msgid "Save annotation"
 msgstr "Salvează adnotare"
 
-#: src/annotation/templates/annotation/index.html:64
+#: src/annotation/templates/annotation/index.html:42
 msgid "Mark complete"
 msgstr "Marchează finalizată"
 

--- a/src/annotation/models.py
+++ b/src/annotation/models.py
@@ -83,6 +83,16 @@ class Entry(models.Model):
     id = models.AutoField(verbose_name="id", primary_key=True)
     text = models.TextField(max_length=250_000, null=False)
 
+    @property
+    def title_word(self):
+        """Get the title word of the entry."""
+        return self.__str__()
+
+    @property
+    def text_length(self):
+        """Get the text length of the entry."""
+        return len(self.text) if self.text is not None else 0
+
     class Meta:
         """Defines metadata of the Entry model."""
 

--- a/src/annotation/models.py
+++ b/src/annotation/models.py
@@ -166,6 +166,11 @@ class Annotation(models.Model):
     row_update_timestamp = models.DateTimeField(
         auto_now=True, verbose_name=_('row update timestamp'))
 
+    @property
+    def text_length(self):
+        """Get the text length of the entry."""
+        return len(self.text) if self.text is not None else 0
+
     def __str__(self):
         """Override the string representation of the model."""
         return extract_entry(self.text)


### PR DESCRIPTION
Added columns `title word`, and `text length` for `Entry` model, and column `text length` to the Annotation model in the admin site.

This pull request closes #11.