### PR TITLE
Use only approved references and apply preprocessing when creating annotation

### DIFF
--- a/src/annotation/utils/automaticannotation.py
+++ b/src/annotation/utils/automaticannotation.py
@@ -1,9 +1,26 @@
 """Automatic annotation of entry texts."""
-import ahocorasick
 from annotation.utils.xml2edtlrmd import Marks
 from collections import namedtuple
+import ahocorasick
+import re
 
 TextRef = namedtuple('TextRef', ['start_index', 'end_index', 'reference'])
+
+
+def apply_preprocessing(text: str) -> str:
+    """Apply some preprocessing to the input string.
+
+    Parameters
+    ----------
+    text: str, required
+        The string to which to apply preprocessing.
+
+    Returns
+    -------
+    processed_text: str
+        The processed text.
+    """
+    return re.sub('\n+', '\n', text)
 
 
 class ReferenceAnnotator:

--- a/src/annotation/utils/automaticannotation.py
+++ b/src/annotation/utils/automaticannotation.py
@@ -17,12 +17,8 @@ class ReferenceAnnotator:
         references: list of str, required
             The list of references.
         """
-        self.__references = references
-        self.__automaton = ahocorasick.Automaton()
-        for idx, key in enumerate(references):
-            key = key.strip()
-            self.__automaton.add_word(key, (idx, key))
-        self.__automaton.make_automaton()
+        self.__references = references if references is not None else []
+        self.__automaton = self.__make_automaton()
 
     def annotate(self, text: str) -> str:
         """Annotate the references in the specified text.
@@ -37,6 +33,9 @@ class ReferenceAnnotator:
         annotated_text: str
             The annotated text.
         """
+        if len(self.__references) == 0:
+            return text
+
         text = text.replace(Marks.REFERENCE, "")
         found_refs = self.__search_references(text)
         found_refs.sort(key=lambda ref: ref.start_index)
@@ -112,3 +111,19 @@ class ReferenceAnnotator:
             ref = TextRef(start_idx, end_idx, original_value)
             found_refs.append(ref)
         return found_refs
+
+    def __make_automaton(self) -> ahocorasick.Automaton:
+        """Make the automaton for fast searching of references.
+
+        Returns
+        -------
+        automaton: ahocorasick.Automaton
+            The automaton for fast search within text.
+        """
+        automaton = ahocorasick.Automaton()
+        if len(self.__references) > 0:
+            for idx, key in enumerate(self.__references):
+                key = key.strip()
+                automaton.add_word(key, (idx, key))
+            automaton.make_automaton()
+        return automaton

--- a/src/annotation/views/newannotation.py
+++ b/src/annotation/views/newannotation.py
@@ -29,7 +29,10 @@ class NewAnnotationView(LoginRequiredMixin, View):
         refs = cache.get(CACHE_KEY)
         if refs is None:
             print("Loading all references.")
-            refs = list(Reference.objects.values_list('text', flat=True))
+            refs = Reference.objects\
+                            .filter(is_approved=True)\
+                            .values_list('text', flat=True)
+            refs = list(refs)
             cache.set(CACHE_KEY, refs, CACHE_TIMEOUT)
         return refs
 

--- a/src/annotation/views/newannotation.py
+++ b/src/annotation/views/newannotation.py
@@ -5,6 +5,7 @@ from annotation.models.entrypage import EntryPage
 from annotation.models.page import Page
 from annotation.models.reference import Reference
 from annotation.utils.automaticannotation import ReferenceAnnotator
+from annotation.utils.automaticannotation import apply_preprocessing
 from annotation.views.viewsettings import MAX_CONCURRENT_ANNOTATORS
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.models import User
@@ -108,7 +109,7 @@ class NewAnnotationView(LoginRequiredMixin, View):
         status = Annotation.AnnotationStatus.IN_PROGRESS
         record = Annotation(entry=entry, user=user, status=status)
         annotator = ReferenceAnnotator(self.references)
-        text = annotator.annotate(entry.text)
+        text = annotator.annotate(apply_preprocessing(entry.text))
         record.set_text(text)
         record.save()
         return record


### PR DESCRIPTION
When the user requests a new annotation, the application will apply preprocessing to the entry text, and then --- automatic annotation of references.

The preprocessing, for now, is only replacing multiple new-line characters with a single one.

For the automatic annotation of references the application will load only the references that have the `is_approved` flag set to `True`.

This pull-request closes #74.