### PR TITLE
Set headword as the text of new annotation when typing entries

### DIFF
--- a/src/annotation/views/newannotation.py
+++ b/src/annotation/views/newannotation.py
@@ -137,10 +137,12 @@ class AnnotationFactory:
         status = Annotation.AnnotationStatus.IN_PROGRESS
         record = Annotation(entry=entry, user=user, status=status)
 
-        text = ''
-        if APPLICATION_MODE == ApplicationModes.AnnotateEntries:
-            annotator = ReferenceAnnotator(references)
-            text = annotator.annotate(apply_preprocessing(entry.text))
+        match APPLICATION_MODE:
+            case ApplicationModes.AnnotateEntries:
+                annotator = ReferenceAnnotator(references)
+                text = annotator.annotate(apply_preprocessing(entry.text))
+            case _:
+                text = f'**{entry.title_word}**'
         record.set_text(text)
 
         record.title_word = entry.title_word


### PR DESCRIPTION
When the application is running in the `Write entries` mode, the text of the new annotation will be set to the headword of the entry, in order to signal to the user which entry to pick from the page scan.

This pull-request closes #99.