### PR TITLE
Removed the `fixed-bottom` class from footer to avoid overlap

### DIFF
--- a/src/annotation/static/annotation/assets/style.css
+++ b/src/annotation/static/annotation/assets/style.css
@@ -82,10 +82,6 @@
     z-index: 1024;
 }
 
-#content{
-    padding-bottom: 84px;
-}
-
 footer p{
     font-size: smaller;
 }

--- a/src/annotation/templates/annotation/base.html
+++ b/src/annotation/templates/annotation/base.html
@@ -29,7 +29,7 @@
     <div id="content" class="container-fluid">
       {% block content %}{% endblock %}
     </div>
-    <footer class="py-3 my-4 fixed-bottom">
+    <footer class="py-3 my-4">
       <p class="text-center text-muted">
         <span>&copy; {% now 'Y' %}</span>
       </p>


### PR DESCRIPTION
The class `fixed-bottom` on the `footer` element made the footer overlap with the annotation buttons.

This pull-request closes #112.