### PR TITLE
Implemented search of entry page models in the admin page

### DIFF
--- a/src/annotation/admin.py
+++ b/src/annotation/admin.py
@@ -11,7 +11,6 @@ from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
 
 
-# Register your models here.
 class VolumeAdmin(admin.ModelAdmin):
     """Overrides the default admin options for Volume."""
 
@@ -39,8 +38,16 @@ class EntryAdmin(admin.ModelAdmin):
 class EntryPageAdmin(admin.ModelAdmin):
     """Overrides the default admin options for EntryPage."""
 
-    list_display = ["entry", "page"]
-    list_filter = ["page"]
+    @admin.display(description=_('volume'))
+    def volume_name(self, obj):
+        """Get the volume name of the entry page."""
+        return obj.page.volume.name
+
+    list_display = ["entry", "page", "volume_name"]
+
+    search_fields = [
+        "entry__title_word_normalized__icontains", "page__page_no__iexact"
+    ]
 
 
 class EvaluationIntervalFilter(admin.SimpleListFilter):


### PR DESCRIPTION
The search logic will query the normalized headword of the entry
using the `icontains` lookup, and the page number.

To differentiate between results, the column `Volume` was added to the
list page.

This pull-request closes #51.